### PR TITLE
De-virtualized calls to determine type of RVMType objects

### DIFF
--- a/rvm/src/org/jikesrvm/classloader/Primitive.java
+++ b/rvm/src/org/jikesrvm/classloader/Primitive.java
@@ -101,6 +101,7 @@ public final class Primitive extends RVMType {
           -1,    // dimensionality
           null  // runtime visible annotations
     );
+    isPrimitiveType = true;
     this.name = name;
     this.stackWords = stackWords;
     this.memoryBytes = memoryBytes;
@@ -266,56 +267,6 @@ public final class Primitive extends RVMType {
   public Offset getThinLockOffset() {
     if (VM.VerifyAssertions) VM._assert(NOT_REACHED);
     return Offset.max();
-  }
-
-  /**
-   * @return <code>false</code>
-   */
-  @Override
-  @Pure
-  @Uninterruptible
-  public boolean isClassType() {
-    return false;
-  }
-
-  /**
-   * @return <code>false</code>
-   */
-  @Override
-  @Pure
-  @Uninterruptible
-  public boolean isArrayType() {
-    return false;
-  }
-
-  /**
-   * @return <code>true</code>
-   */
-  @Override
-  @Pure
-  @Uninterruptible
-  public boolean isPrimitiveType() {
-    return true;
-  }
-
-  /**
-   * @return <code>false</code>
-   */
-  @Override
-  @Pure
-  @Uninterruptible
-  public boolean isReferenceType() {
-    return false;
-  }
-
-  /**
-   * @return <code>false</code>
-   */
-  @Override
-  @Pure
-  @Uninterruptible
-  public boolean isUnboxedType() {
-    return false;
   }
 
   /**

--- a/rvm/src/org/jikesrvm/classloader/RVMArray.java
+++ b/rvm/src/org/jikesrvm/classloader/RVMArray.java
@@ -363,58 +363,10 @@ public final class RVMArray extends RVMType {
     return ObjectModel.defaultThinLockOffset();
   }
 
-  /**
-   * @return <code>false</code>
-   */
-  @Override
-  @Pure
-  @Uninterruptible
-  public boolean isClassType() {
-    return false;
-  }
-
-  /**
-   * @return <code>true</code>
-   */
-  @Override
-  @Pure
-  @Uninterruptible
-  public boolean isArrayType() {
-    return true;
-  }
-
-  /**
-   * @return <code>false</code>
-   */
-  @Override
-  @Pure
-  @Uninterruptible
-  public boolean isPrimitiveType() {
-    return false;
-  }
-
-  /**
-   * @return <code>true</code>
-   */
-  @Override
-  @Pure
-  @Uninterruptible
-  public boolean isReferenceType() {
-    return true;
-  }
-
-  /**
-   * @return <code>false</code>
-   */
-  @Override
-  @Pure
-  @Uninterruptible
-  public boolean isUnboxedType() {
-    return false;
-  }
-
   RVMArray(TypeReference typeRef, RVMType elementType) {
     super(typeRef, typeRef.getDimensionality(), null);
+    isArrayType = true;
+    isReferenceType = true;
     this.elementType = elementType;
     this.logElementSize = computeLogElementSize();
     depth = 1;

--- a/rvm/src/org/jikesrvm/classloader/RVMClass.java
+++ b/rvm/src/org/jikesrvm/classloader/RVMClass.java
@@ -1021,6 +1021,8 @@ public final class RVMClass extends RVMType {
            MethodReference enclosingMethod, Atom sourceName, RVMMethod classInitializerMethod,
            Atom signature, RVMAnnotation[] annotations) {
     super(typeRef, 0, annotations);
+    isClassType = true;
+    isReferenceType = true;
     if (VM.VerifyAssertions) VM._assert(!getTypeRef().isUnboxedType());
     if (VM.VerifyAssertions && null != superClass) VM._assert(!superClass.getTypeRef().isUnboxedType());
 
@@ -1912,56 +1914,6 @@ public final class RVMClass extends RVMType {
   @Uninterruptible
   public int getTypeDepth() {
     return depth;
-  }
-
-  /**
-   * @return <code>true</code>
-   */
-  @Override
-  @Pure
-  @Uninterruptible
-  public boolean isClassType() {
-    return true;
-  }
-
-  /**
-   * @return <code>false</code>
-   */
-  @Override
-  @Pure
-  @Uninterruptible
-  public boolean isArrayType() {
-    return false;
-  }
-
-  /**
-   * @return <code>false</code>
-   */
-  @Override
-  @Pure
-  @Uninterruptible
-  public boolean isPrimitiveType() {
-    return false;
-  }
-
-  /**
-   * @return <code>true</code>
-   */
-  @Override
-  @Pure
-  @Uninterruptible
-  public boolean isReferenceType() {
-    return true;
-  }
-
-  /**
-   * @return <code>false</code>
-   */
-  @Override
-  @Pure
-  @Uninterruptible
-  public boolean isUnboxedType() {
-    return false;
   }
 
   public static boolean isClassLoadingDisabled() {

--- a/rvm/src/org/jikesrvm/classloader/RVMType.java
+++ b/rvm/src/org/jikesrvm/classloader/RVMType.java
@@ -728,40 +728,55 @@ public abstract class RVMType extends AnnotatedElement {
   @Uninterruptible
   public abstract Offset getThinLockOffset();
 
+  protected boolean isClassType = false;
+  protected boolean isArrayType = false;
+  protected boolean isPrimitiveType = false;
+  protected boolean isUnboxedType = false;
+  protected boolean isReferenceType = false;
   /**
    * Is this is an instance of RVMClass?
    * @return whether or not this is an instance of RVMClass?
    */
   @Uninterruptible
-  public abstract boolean isClassType();
+  public final boolean isClassType() {
+    return isClassType;
+  }
 
   /**
    * Is this an instance of RVMArray?
    * @return whether or not this is an instance of RVMArray?
    */
   @Uninterruptible
-  public abstract boolean isArrayType();
+  public final boolean isArrayType() {
+    return isArrayType;
+  }
 
   /**
    * Is this a primitive type?
    * @return whether or not this is a primitive type
    */
   @Uninterruptible
-  public abstract boolean isPrimitiveType();
+  public final boolean isPrimitiveType() {
+    return isPrimitiveType;
+  }
 
   /**
    * Is this an unboxed type?
    * @return whether or not this is an unboxed type
    */
   @Uninterruptible
-  public abstract boolean isUnboxedType();
+  public final boolean isUnboxedType() {
+    return isUnboxedType;
+  }
 
   /**
    * Is this a reference type?
    * @return whether or not this is a reference (ie non-primitive) type.
    */
   @Uninterruptible
-  public abstract boolean isReferenceType();
+  public final boolean isReferenceType() {
+    return isReferenceType;
+  }
 
   /**
    * @param type type to checj

--- a/rvm/src/org/jikesrvm/classloader/UnboxedType.java
+++ b/rvm/src/org/jikesrvm/classloader/UnboxedType.java
@@ -76,6 +76,7 @@ public final class UnboxedType extends RVMType {
           -1,    // dimensionality
           null  // runtime visible annotations
     );
+    isUnboxedType = true;
     this.name = name;
     this.stackWords = stackWords;
     this.memoryBytes = memoryBytes;
@@ -199,56 +200,6 @@ public final class UnboxedType extends RVMType {
   public Offset getThinLockOffset() {
     if (VM.VerifyAssertions) VM._assert(NOT_REACHED);
     return Offset.max();
-  }
-
-  /**
-   * @return <code>false</code>
-   */
-  @Override
-  @Pure
-  @Uninterruptible
-  public boolean isClassType() {
-    return false;
-  }
-
-  /**
-   * @return <code>false</code>
-   */
-  @Override
-  @Pure
-  @Uninterruptible
-  public boolean isArrayType() {
-    return false;
-  }
-
-  /**
-   * @return <code>false</code>
-   */
-  @Override
-  @Pure
-  @Uninterruptible
-  public boolean isPrimitiveType() {
-    return false;
-  }
-
-  /**
-   * @return <code>false</code>
-   */
-  @Override
-  @Pure
-  @Uninterruptible
-  public boolean isReferenceType() {
-    return false;
-  }
-
-  /**
-   * @return <code>true</code>
-   */
-  @Override
-  @Pure
-  @Uninterruptible
-  public boolean isUnboxedType() {
-    return true;
   }
 
   /**


### PR DESCRIPTION
This should be a performance improvement. Before this change, to
determine e.g. if an object is an array, one would need to call
the isArrayType() method on it's type, for a grabd total of 4
indirections:

Object -> TIB (of Object)  -> RVMType -> TIB (of RVMType) -> isArrayType()